### PR TITLE
ci: codecov upload issue

### DIFF
--- a/.github/workflows/validate-code-and-image.yml
+++ b/.github/workflows/validate-code-and-image.yml
@@ -35,6 +35,9 @@ jobs:
     needs:
       - lint-format-test
     steps:
+      # The checkout step should not be necessary but adding to work around CodeCov upload issue
+      # see: https://github.com/codecov/codecov-action/issues/1801
+      - uses: actions/checkout@v4
       - name: Fetch code coverage artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Attempts to work around https://github.com/codecov/codecov-action/issues/1801 by adding a checkout step to the job that uploads the coverage report to CodeCov.